### PR TITLE
Add additional build info properties and parameterize VcsType

### DIFF
--- a/src/commands/build-information.yml
+++ b/src/commands/build-information.yml
@@ -81,10 +81,9 @@ parameters:
     default: ""
   vcs_type:
     description: |
-      [Optional] The type of VCS used. Defaults to 'Git'.
-    type: enum
-    default: "Git"
-    enum: ["Git", "TFVC"]
+      [Optional] The type of VCS used. Defaults to 'GitHub'.
+    type: string
+    default: "GitHub"
 steps:
   - run:
       name: "Push build information for << parameters.package_id >>"

--- a/src/commands/build-information.yml
+++ b/src/commands/build-information.yml
@@ -79,6 +79,12 @@ parameters:
       [Optional] The log level. Valid options are verbose, debug, information, warning, error and fatal. Defaults to 'debug'.
     type: string
     default: ""
+  vcs_type:
+    description: |
+      [Optional] The type of VCS used. Defaults to 'Git'.
+    type: enum
+    default: "Git"
+    enum: ["Git", "TFVC"]
 steps:
   - run:
       name: "Push build information for << parameters.package_id >>"
@@ -107,7 +113,9 @@ steps:
           BuildNumber: "$CIRCLE_BUILD_NUM",
           BuildUrl: "$CIRCLE_BUILD_URL",
           Branch: "$CIRCLE_BRANCH",
-          VcsType: "GitHub"
+          VcsType: "<< parameters.vcs_type >>",
+          VcsRoot: "$CIRCLE_REPOSITORY_URL",
+          VcsCommitNumber: "$CIRCLE_SHA1"
         }
         EOL
 


### PR DESCRIPTION
This PR does two things. 

1. Allows users to set the `VcsType` used in the build information. Defaults to `GitHub`.
2. Add the additional build information properties `VcsRoot` and `VcsCommitNumber`. Build information submitted without a `VcsRoot` is 100% functional but complains about `No VCS root configured` (shown below). 
![image](https://user-images.githubusercontent.com/8612198/152411295-2a60eb0b-d67a-4589-9ec3-07d17a5f5e3a.png)

This may also fix an issue when `create-release` is called. My `create-release` job errors with the following. 

```
Creating release...
There was a problem with your request.

 - GitHub: No VCS root configured

Error from Octopus Server (HTTP 400 BadRequest)
Exit code: -7
```